### PR TITLE
Versioned layer name

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -70,3 +70,7 @@ RUN cd ./share/lib/ && \
 #
 RUN cd ./share && \
   zip --symlinks -r libvips.zip .
+
+# Store the VIPS_VERSION variable in a file, accessible to the deploy script.
+#
+RUN echo VIPS_VERSION=$VIPS_VERSION >> $WORKDIR/share/.env

--- a/bin/build
+++ b/bin/build
@@ -16,4 +16,4 @@ docker build \
 docker run --rm \
   -v "${PWD}/share:/share" \
   $IMAGE_NAME \
-  sh -c "cp /build/share/libvips.zip /share"
+  sh -c "cp /build/share/{libvips.zip,.env} /share"

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,6 +4,8 @@ set -e
 
 ./bin/build
 
+. ./share/.env
+
 LAYER_NAME="rubyvips${VIPS_VERSION//./}"
 
 aws lambda publish-layer-version \

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,7 +4,9 @@ set -e
 
 ./bin/build
 
+LAYER_NAME="rubyvips${VIPS_VERSION//./}"
+
 aws lambda publish-layer-version \
-  --layer-name "rubyvips891" \
+  --layer-name $LAYER_NAME \
   --description "Libvips for Ruby FFI." \
   --zip-file "fileb://$(pwd)/share/libvips.zip"


### PR DESCRIPTION
I think I understand your suggestion in your comment on issue https://github.com/customink/ruby-vips-lambda/issues/9 - is that to ensure that if the scripts are run without an explicit VIPS_VERSION being set, or if the Dockerfile is run without the build.sh script, then the deploy.sh script will still have access to the version info? And, the version used in the Dockerfile is canonical?

The Dockerfile in this PR creates a file named `.env` which is copied (with the zip file) to the host and is then sourced by the deploy.sh script. I guess, in future, additional build variables can also be stored in there if the user needs access to those after the library is built.

Layers cannot contain a `.` so I'm just droppping these with `${VIPS_VERSION//./}`

I've tested deployments with:
    1. `bin/deploy` - which builds v8.7.4 (the default in bin/build) and publishes as `rubyvips874`
    2. `VIPS_VERSION=8.9.2 bin/deploy` which builds v8.9.2 and publishes as `rubyvips892`
    3. `VIPS_VERSION=8.9.0-rc4 bin/deploy` (just to check the edge case version name) which builds v8.9.0-rc4 and publishes as `rubyvips890-rc4`

