### PR TITLE
Ruby 2.7 🎬2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,10 +65,14 @@ RUN cd ./libvips && \
 RUN mkdir -p share/lib && \
   cp -a $INSTALLDIR/lib/libvips.so* $WORKDIR/share/lib/
 
-# Create sym links for ruby-ffi gem's `glib_libname` and `gobject_libname` to work.
+# Copy glib and gobject with their deps over.
 RUN cd ./share/lib/ && \
   cp /usr/lib64/libglib-2.0* . && \
-  cp /usr/lib64/libgobject-2.0* .
+  cp /usr/lib64/libgobject-2.0* . && \
+  cp /usr/lib64/libgthread-2.0* . && \
+  cp /usr/lib64/libgmodule-2.0* . && \
+  cp /usr/lib64/libexpat* . && \
+  ldconfig
 
 # Zip up contents so final `lib` can be placed in /opt layer.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -67,8 +67,8 @@ RUN mkdir -p share/lib && \
 
 # Create sym links for ruby-ffi gem's `glib_libname` and `gobject_libname` to work.
 RUN cd ./share/lib/ && \
-  ln -s /usr/lib64/libglib-2.0.so.0 libglib-2.0.so && \
-  ln -s /usr/lib64/libgobject-2.0.so.0 libgobject-2.0.so
+  cp /usr/lib64/libglib-2.0* . && \
+  cp /usr/lib64/libgobject-2.0* .
 
 # Zip up contents so final `lib` can be placed in /opt layer.
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,13 +2,12 @@ FROM lambci/lambda:build-ruby2.7
 
 WORKDIR /build
 
-ARG VIPS_VERSION=8.9.1
-ARG IMAGEQUANT_VERSION=2.12.6
+ARG VIPS_VERSION=8.9.2
 
-ENV WORKDIR="/build"
-ENV INSTALLDIR="/opt"
 ENV VIPS_VERSION=$VIPS_VERSION
-ENV IMAGEQUANT_VERSION=$IMAGEQUANT_VERSION
+ENV PATH=/opt/bin:$PATH
+ENV LD_LIBRARY_PATH=/opt/lib:/opt/lib64:$LD_LIBRARY_PATH
+ENV PKG_CONFIG_PATH=/opt/lib/pkgconfig:/opt/lib64/pkgconfig
 
 # Setup Some Dirs
 #
@@ -16,69 +15,126 @@ RUN mkdir -p \
     share/lib \
     share/include
 
-# Install xpat
+# Install expat
 #
-RUN yum install -y expat-devel
+RUN curl https://codeload.github.com/libexpat/libexpat/zip/R_2_2_9 > libexpat-R_2_2_9.zip && \
+    unzip libexpat-R_2_2_9.zip && \
+    cd ./libexpat-R_2_2_9/expat && \
+    ./buildconf.sh && \
+    ./configure --prefix=/opt && \
+    make install
 
-# Install libimagequant. Details: https://github.com/libvips/libvips/pull/1009
+RUN cp -a /opt/lib/libexpat.so* /build/share/lib
+
+# Install libpng
 #
-RUN git clone git://github.com/ImageOptim/libimagequant.git && \
+RUN curl -L https://downloads.sourceforge.net/libpng/libpng-1.6.37.tar.xz > libpng-1.6.37.tar.xz && \
+    tar -xf libpng-1.6.37.tar.xz && \
+    cd libpng-1.6.37 && \
+    ./configure --prefix=/opt --disable-static && \
+    make && \
+    make install
+
+RUN cp -a /opt/lib/libpng.so* /build/share/lib && \
+    cp -a /opt/lib/libpng16.so* /build/share/lib
+
+# Install giflib
+#
+RUN curl -L https://sourceforge.net/projects/giflib/files/giflib-5.2.1.tar.gz > giflib-5.2.1.tar.gz && \
+    tar -xf giflib-5.2.1.tar.gz && \
+    cd giflib-5.2.1 && \
+    make && \
+    make PREFIX=/opt install
+
+RUN cp -a /opt/lib/libgif.so* /build/share/lib
+
+# Install libjpeg-turbo
+#
+RUN curl -L https://downloads.sourceforge.net/libjpeg-turbo/libjpeg-turbo-2.0.4.tar.gz > libjpeg-turbo-2.0.4.tar.gz && \
+    tar -xf libjpeg-turbo-2.0.4.tar.gz && \
+    cd libjpeg-turbo-2.0.4 && \
+    cmake -DCMAKE_INSTALL_PREFIX=/opt && \
+    make && \
+    make install
+
+RUN cp -a /opt/lib64/libjpeg.so* /build/share/lib && \
+    cp -a /opt/lib64/libturbojpeg.so* /build/share/lib
+
+# Install libimagequant
+#
+RUN git clone https://github.com/ImageOptim/libimagequant.git && \
     cd ./libimagequant && \
-    git checkout "${IMAGEQUANT_VERSION}" && \
-    CC=clang CXX=clang++ ./configure --prefix=/opt && \
+    git checkout 2.12.6 && \
+    ./configure --prefix=/opt && \
     make libimagequant.so && \
     make install && \
     echo /opt/lib > /etc/ld.so.conf.d/libimagequant.conf && \
     ldconfig
-RUN cp -a $INSTALLDIR/lib/libimagequant.so* $WORKDIR/share/lib/ && \
-    cp -a $INSTALLDIR/include/libimagequant.h $WORKDIR/share/include/
 
+RUN cp -a /opt/lib/libimagequant.so* /build/share/lib/ && \
+    cp -a /opt/include/libimagequant.h /build/share/include/
 
-# Install deps for libvips. Details: https://libvips.github.io/libvips/install.html
+# Install libvips. Primary deps https://libvips.github.io/libvips/install.html
 #
 RUN yum install -y \
-  gtk-doc \
-  gobject-introspection \
-  gobject-introspection-devel
+    gtk-doc \
+    ninja-build
 
-# Clone repo and checkout version tag.
+RUN pip3 install meson && \
+    pip3 install ninja
+
+RUN curl -L http://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz > glib-2.64.2.tar.xz && \
+    tar -xf glib-2.64.2.tar.xz && \
+    cd glib-2.64.2 && \
+    mkdir ./_build && \
+    cd ./_build && \
+    meson --prefix=/opt .. && \
+    ninja && \
+    ninja install
+
+RUN cp -a /opt/lib64/libffi.so* /build/share/lib && \
+    cp -a /opt/lib64/libglib-2.0.so* /build/share/lib && \
+    cp -a /opt/lib64/libgmodule-2.0.so* /build/share/lib && \
+    cp -a /opt/lib64/libgobject-2.0.so* /build/share/lib && \
+    cp -a /opt/lib64/libgthread-2.0.so* /build/share/lib
+
+RUN curl -L http://ftp.gnome.org/pub/gnome/sources/gobject-introspection/1.64/gobject-introspection-1.64.1.tar.xz > gobject-introspection-1.64.1.tar.xz && \
+    tar -xf gobject-introspection-1.64.1.tar.xz && \
+    cd gobject-introspection-1.64.1 && \
+    mkdir ./_build && \
+    cd ./_build && \
+    meson --prefix=/opt .. && \
+    ninja && \
+    ninja install
+
+# Install libvips.
 #
-RUN git clone git://github.com/libvips/libvips.git && \
-  cd libvips && \
-  git checkout "v${VIPS_VERSION}"
+RUN curl -L https://github.com/libvips/libvips/releases/download/v${VIPS_VERSION}/vips-${VIPS_VERSION}.tar.gz > vips-${VIPS_VERSION}.tar.gz && \
+    tar -xf vips-${VIPS_VERSION}.tar.gz && \
+    cd vips-${VIPS_VERSION} && \
+    ./configure \
+      --prefix=/opt \
+      --disable-gtk-doc \
+      --without-magick \
+      --with-expat=/opt \
+      --with-giflib-includes=/opt/local/include \
+      --with-giflib-libraries=/opt/local/lib && \
+    make && \
+    make install && \
+    echo /opt/lib > /etc/ld.so.conf.d/libvips.conf && \
+    ldconfig
 
-# Compile from source.
+RUN cp -a /opt/lib/libvips.so* /build/share/lib
+
+# Store the VIPS_VERSION variable in a file, accessible to the deploy script.
 #
-RUN cd ./libvips && \
-  CC=clang CXX=clang++ \
-  IMAGEQUANT_CFLAGS="-I/opt/include" \
-  IMAGEQUANT_LIBS="-L/opt/lib -limagequant" \
-  ./autogen.sh \
-  --prefix=${INSTALLDIR} \
-  --disable-static && \
-  make install && \
-  echo /opt/lib > /etc/ld.so.conf.d/libvips.conf && \
-  ldconfig
+RUN echo $VIPS_VERSION > "./share/VIPS_VERSION"
 
-# Copy only needed so files to new share/lib.
+# Create an /build/share/opt/lib64 symlink for shared objects.
 #
-RUN mkdir -p share/lib && \
-  cp -a $INSTALLDIR/lib/libvips.so* $WORKDIR/share/lib/
-
-# Copy glib and gobject with their deps over.
-RUN cd ./share/lib/ && \
-  cp /usr/lib64/libglib-2.0* . && \
-  cp /usr/lib64/libgobject-2.0* . && \
-  cp /usr/lib64/libgthread-2.0* . && \
-  cp /usr/lib64/libgmodule-2.0* . && \
-  cp /usr/lib64/libexpat* . && \
-  ldconfig
+RUN cd ./share && ln -s lib lib64
 
 # Zip up contents so final `lib` can be placed in /opt layer.
 #
 RUN cd ./share && \
-  zip --symlinks -r libvips.zip .
-
-# Store the VIPS_VERSION variable in a file, accessible to the deploy script.
-#
-RUN echo $VIPS_VERSION >> $WORKDIR/share/.VIPS_VERSION
+    zip --symlinks -r libvips.zip .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lambci/lambda:build-ruby2.5
+FROM lambci/lambda:build-ruby2.7
 
 WORKDIR /build
 
@@ -15,6 +15,10 @@ ENV IMAGEQUANT_VERSION=$IMAGEQUANT_VERSION
 RUN mkdir -p \
     share/lib \
     share/include
+
+# Install xpat
+#
+RUN yum install -y expat-devel
 
 # Install libimagequant. Details: https://github.com/libvips/libvips/pull/1009
 #

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ From there you simply use the arn in your AWS SAM `template.yaml` file.
 
 Simplicity and small file size! We followed the [docs](https://libvips.github.io/libvips/install.html) for `libvips` install. But because AWS Lambda already has ImageMagick and lots of the needed dependencies, the work was very basic.
 
-We used the `lambci/lambda:build-ruby2.5` Docker image from the [docker-lambda](https://github.com/lambci/docker-lambda) project. From there we only had to install a few more dependencies to get libvips installed. The current version is `v8.7.4` and easy to configure if you need something else.
+We used the `lambci/lambda:build-ruby2.7` Docker image from the [docker-lambda](https://github.com/lambci/docker-lambda) project. From there we only had to install a few more dependencies to get libvips installed. The current version is `v8.7.4` and easy to configure if you need something else.
 
 Lastly, we were happy to find that `glib` and `gobject` were already installed and all that was needed were some simple sym links so FFI could load these libraries.
 

--- a/README.md
+++ b/README.md
@@ -29,31 +29,46 @@ Lastly, we were happy to find that `glib` and `gobject` were already installed a
 
 ## Contents
 
-Current size of the layer's un-compressed contents is around `15MB` in size.
+Current size of the layer's un-compressed contents is around `21MB` in size. Contents include:
 
 ```shell
 $ ls -lAGp /opt/lib
--rwxr-xr-x  1 root   201K Apr 27 20:30 libexpat.so
--rwxr-xr-x  1 root   201K Apr 27 20:30 libexpat.so.1
--rwxr-xr-x  1 root   201K Apr 27 20:30 libexpat.so.1.6.0
--rwxr-xr-x  1 root   1.1M Apr 27 20:30 libglib-2.0.so
--rwxr-xr-x  1 root   1.1M Apr 27 20:30 libglib-2.0.so.0
--rwxr-xr-x  1 root   1.1M Apr 27 20:30 libglib-2.0.so.0.5600.1
--rwxr-xr-x  1 root    15K Apr 27 20:30 libgmodule-2.0.so
--rwxr-xr-x  1 root    15K Apr 27 20:30 libgmodule-2.0.so.0
--rwxr-xr-x  1 root    15K Apr 27 20:30 libgmodule-2.0.so.0.5600.1
--rwxr-xr-x  1 root   327K Apr 27 20:30 libgobject-2.0.so
--rwxr-xr-x  1 root   327K Apr 27 20:30 libgobject-2.0.so.0
--rwxr-xr-x  1 root   327K Apr 27 20:30 libgobject-2.0.so.0.5600.1
--rwxr-xr-x  1 root   6.7K Apr 27 20:30 libgthread-2.0.so
--rwxr-xr-x  1 root   6.7K Apr 27 20:30 libgthread-2.0.so.0
--rwxr-xr-x  1 root   6.7K Apr 27 20:30 libgthread-2.0.so.0.5600.1
-lrwxrwxrwx  1 root    18B Apr 27 20:26 libimagequant.so -> libimagequant.so.0
--rw-r--r--  1 root    65K Apr 27 20:26 libimagequant.so.0
-lrwxrwxrwx  1 root    18B Apr 27 20:29 libvips.so -> libvips.so.42.12.2
-lrwxrwxrwx  1 root    18B Apr 27 20:29 libvips.so.42 -> libvips.so.42.12.2
--rwxr-xr-x  1 root   9.6M Apr 27 20:29 libvips.so.42.12.2
+lrwxrwxrwx  1 root    18B Apr 29 23:53 libexpat.so -> libexpat.so.1.6.11
+lrwxrwxrwx  1 root    18B Apr 29 23:53 libexpat.so.1 -> libexpat.so.1.6.11
+-rwxr-xr-x  1 root   543K Apr 29 23:53 libexpat.so.1.6.11
+lrwxrwxrwx  1 root    11B Apr 29 23:53 libffi.so -> libffi.so.7
+lrwxrwxrwx  1 root    15B Apr 29 23:53 libffi.so.7 -> libffi.so.7.1.0
+-rwxr-xr-x  1 root   158K Apr 29 23:53 libffi.so.7.1.0
+lrwxrwxrwx  1 root    11B Apr 29 23:53 libgif.so -> libgif.so.7
+lrwxrwxrwx  1 root    15B Apr 29 23:53 libgif.so.7 -> libgif.so.7.2.0
+-rwxr-xr-x  1 root    36K Apr 29 23:53 libgif.so.7.2.0
+lrwxrwxrwx  1 root    16B Apr 29 23:53 libglib-2.0.so -> libglib-2.0.so.0
+lrwxrwxrwx  1 root    23B Apr 29 23:53 libglib-2.0.so.0 -> libglib-2.0.so.0.6400.2
+-rwxr-xr-x  1 root   4.7M Apr 29 23:53 libglib-2.0.so.0.6400.2
+lrwxrwxrwx  1 root    19B Apr 29 23:53 libgmodule-2.0.so -> libgmodule-2.0.so.0
+lrwxrwxrwx  1 root    26B Apr 29 23:53 libgmodule-2.0.so.0 -> libgmodule-2.0.so.0.6400.2
+-rwxr-xr-x  1 root    49K Apr 29 23:53 libgmodule-2.0.so.0.6400.2
+lrwxrwxrwx  1 root    19B Apr 29 23:53 libgobject-2.0.so -> libgobject-2.0.so.0
+lrwxrwxrwx  1 root    26B Apr 29 23:53 libgobject-2.0.so.0 -> libgobject-2.0.so.0.6400.2
+-rwxr-xr-x  1 root   1.7M Apr 29 23:53 libgobject-2.0.so.0.6400.2
+lrwxrwxrwx  1 root    19B Apr 29 23:53 libgthread-2.0.so -> libgthread-2.0.so.0
+lrwxrwxrwx  1 root    26B Apr 29 23:53 libgthread-2.0.so.0 -> libgthread-2.0.so.0.6400.2
+-rwxr-xr-x  1 root    14K Apr 29 23:53 libgthread-2.0.so.0.6400.2
+lrwxrwxrwx  1 root    18B Apr 29 23:53 libimagequant.so -> libimagequant.so.0
+-rw-r--r--  1 root    85K Apr 29 23:53 libimagequant.so.0
+lrwxrwxrwx  1 root    13B Apr 29 23:53 libjpeg.so -> libjpeg.so.62
+lrwxrwxrwx  1 root    17B Apr 29 23:53 libjpeg.so.62 -> libjpeg.so.62.3.0
+-rwxr-xr-x  1 root   464K Apr 29 23:53 libjpeg.so.62.3.0
+lrwxrwxrwx  1 root    11B Apr 29 23:53 libpng.so -> libpng16.so
+lrwxrwxrwx  1 root    19B Apr 29 23:53 libpng16.so -> libpng16.so.16.37.0
+lrwxrwxrwx  1 root    19B Apr 29 23:53 libpng16.so.16 -> libpng16.so.16.37.0
+-rwxr-xr-x  1 root   891K Apr 29 23:53 libpng16.so.16.37.0
+lrwxrwxrwx  1 root    17B Apr 29 23:53 libturbojpeg.so -> libturbojpeg.so.0
+lrwxrwxrwx  1 root    21B Apr 29 23:53 libturbojpeg.so.0 -> libturbojpeg.so.0.2.0
+-rwxr-xr-x  1 root   583K Apr 29 23:53 libturbojpeg.so.0.2.0
+lrwxrwxrwx  1 root    18B Apr 29 23:53 libvips.so -> libvips.so.42.12.2
+lrwxrwxrwx  1 root    18B Apr 29 23:53 libvips.so.42 -> libvips.so.42.12.2
+-rwxr-xr-x  1 root    11M Apr 29 23:53 libvips.so.42.12.2
 
 $ ls -lAGp /opt/include
--rw-r--r--  1 root    6942 Jan 30 18:08 libimagequant.h
-```
+-rw-r--r--  1 root   6.8K Apr 29 23:53 libimagequant.h```

--- a/README.md
+++ b/README.md
@@ -22,25 +22,38 @@ From there you simply use the arn in your AWS SAM `template.yaml` file.
 
 Simplicity and small file size! We followed the [docs](https://libvips.github.io/libvips/install.html) for `libvips` install. But because AWS Lambda already has ImageMagick and lots of the needed dependencies, the work was very basic.
 
-We used the `lambci/lambda:build-ruby2.7` Docker image from the [docker-lambda](https://github.com/lambci/docker-lambda) project. From there we only had to install a few more dependencies to get libvips installed. The current version is `v8.7.4` and easy to configure if you need something else.
+We used the `lambci/lambda:build-ruby2.7` Docker image from the [docker-lambda](https://github.com/lambci/docker-lambda) project. From there we only had to install a few more dependencies to get libvips installed. The current version is `v8.9.2` and easy to configure if you need something else.
 
 Lastly, we were happy to find that `glib` and `gobject` were already installed and all that was needed were some simple sym links so FFI could load these libraries.
 
 
 ## Contents
 
-Because of the way we build `libvips` by using existing libraries already installed on AWS Lambda, the resulting layer is very small. Only around `10MB` in total un-compressed size.
+Current size of the layer's un-compressed contents is around `15MB` in size.
 
 ```shell
 $ ls -lAGp /opt/lib
-lrwxrwxrwx 1 root      27 Jan 30 18:08 libglib-2.0.so -> /usr/lib64/libglib-2.0.so.0
-lrwxrwxrwx 1 root      30 Jan 30 18:08 libgobject-2.0.so -> /usr/lib64/libgobject-2.0.so.0
-lrwxrwxrwx 1 root      18 Jan 30 18:08 libimagequant.so -> libimagequant.so.0
--rw-r--r-- 1 root   56576 Jan 30 18:08 libimagequant.so.0
-lrwxrwxrwx 1 root      18 Jan 30 18:08 libvips.so -> libvips.so.42.12.1
-lrwxrwxrwx 1 root      18 Jan 30 18:08 libvips.so.42 -> libvips.so.42.12.1
--rwxr-xr-x 1 root 9954128 Jan 30 18:08 libvips.so.42.12.1
+-rwxr-xr-x  1 root   201K Apr 27 20:30 libexpat.so
+-rwxr-xr-x  1 root   201K Apr 27 20:30 libexpat.so.1
+-rwxr-xr-x  1 root   201K Apr 27 20:30 libexpat.so.1.6.0
+-rwxr-xr-x  1 root   1.1M Apr 27 20:30 libglib-2.0.so
+-rwxr-xr-x  1 root   1.1M Apr 27 20:30 libglib-2.0.so.0
+-rwxr-xr-x  1 root   1.1M Apr 27 20:30 libglib-2.0.so.0.5600.1
+-rwxr-xr-x  1 root    15K Apr 27 20:30 libgmodule-2.0.so
+-rwxr-xr-x  1 root    15K Apr 27 20:30 libgmodule-2.0.so.0
+-rwxr-xr-x  1 root    15K Apr 27 20:30 libgmodule-2.0.so.0.5600.1
+-rwxr-xr-x  1 root   327K Apr 27 20:30 libgobject-2.0.so
+-rwxr-xr-x  1 root   327K Apr 27 20:30 libgobject-2.0.so.0
+-rwxr-xr-x  1 root   327K Apr 27 20:30 libgobject-2.0.so.0.5600.1
+-rwxr-xr-x  1 root   6.7K Apr 27 20:30 libgthread-2.0.so
+-rwxr-xr-x  1 root   6.7K Apr 27 20:30 libgthread-2.0.so.0
+-rwxr-xr-x  1 root   6.7K Apr 27 20:30 libgthread-2.0.so.0.5600.1
+lrwxrwxrwx  1 root    18B Apr 27 20:26 libimagequant.so -> libimagequant.so.0
+-rw-r--r--  1 root    65K Apr 27 20:26 libimagequant.so.0
+lrwxrwxrwx  1 root    18B Apr 27 20:29 libvips.so -> libvips.so.42.12.2
+lrwxrwxrwx  1 root    18B Apr 27 20:29 libvips.so.42 -> libvips.so.42.12.2
+-rwxr-xr-x  1 root   9.6M Apr 27 20:29 libvips.so.42.12.2
 
 $ ls -lAGp /opt/include
--rw-r--r-- 1 root    6942 Jan 30 18:08 libimagequant.h
+-rw-r--r--  1 root    6942 Jan 30 18:08 libimagequant.h
 ```

--- a/bin/build
+++ b/bin/build
@@ -2,8 +2,8 @@
 
 set -e
 
-IMAGE_NAME=ruby-vips-lambda
-VIPS_VERSION=${VIPS_VERSION:=8.9.2}
+export IMAGE_NAME=ruby-vips-lambda
+export VIPS_VERSION=${VIPS_VERSION:=8.9.2}
 
 rm -rf ./share
 mkdir ./share
@@ -11,9 +11,11 @@ mkdir ./share
 docker build \
   --no-cache \
   --build-arg VIPS_VERSION=${VIPS_VERSION} \
-  -t $IMAGE_NAME .
+  --tag $IMAGE_NAME \
+  .
 
-docker run --rm \
-  -v "${PWD}/share:/share" \
-  $IMAGE_NAME \
-  sh -c "cp /build/share/{libvips.zip,.VIPS_VERSION} /share"
+docker run \
+  --rm \
+  --volume "${PWD}/share:/share" \
+  "${IMAGE_NAME}:latest" \
+  sh -c "cp -r /build/share/* /share"

--- a/bin/build
+++ b/bin/build
@@ -3,7 +3,7 @@
 set -e
 
 IMAGE_NAME=ruby-vips-lambda
-VIPS_VERSION=${VIPS_VERSION:=8.7.4}
+VIPS_VERSION=${VIPS_VERSION:=8.9.2}
 
 rm -rf ./share
 mkdir ./share

--- a/bin/deploy
+++ b/bin/deploy
@@ -4,8 +4,8 @@ set -e
 
 ./bin/build
 
-VIPS_VERSION=$(cat share/.VIPS_VERSION)
-LAYER_NAME="rubyvips${VIPS_VERSION//./}-27"
+export VIPS_VERSION=$(cat share/VIPS_VERSION)
+export LAYER_NAME="rubyvips${VIPS_VERSION//./}-27"
 
 aws lambda publish-layer-version \
   --layer-name $LAYER_NAME \

--- a/bin/deploy
+++ b/bin/deploy
@@ -5,7 +5,7 @@ set -e
 ./bin/build
 
 VIPS_VERSION=$(cat share/.VIPS_VERSION)
-LAYER_NAME="rubyvips${VIPS_VERSION//./}"
+LAYER_NAME="rubyvips${VIPS_VERSION//./}-27"
 
 aws lambda publish-layer-version \
   --layer-name $LAYER_NAME \


### PR DESCRIPTION
This is a re-do of #11 but rather trying to hack on things that are not on Amazon Linux v2 anymore (GObject, etc) I have changed this layer to build everything needed from scratch. Details include:

* Did not copy `/opt/lib64/libgio-2.0.so` these objects are big and not linked to.
* All shared objects are copied to /opt/lib. We make a symlink from /opt/lib64.
* Update docs on layer size.

