### PR TITLE
Build Libvips v8.10.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ ENV VIPS_VERSION=$VIPS_VERSION
 ENV PATH=/opt/bin:$PATH
 ENV LD_LIBRARY_PATH=/opt/lib:/opt/lib64:$LD_LIBRARY_PATH
 ENV PKG_CONFIG_PATH=/opt/lib/pkgconfig:/opt/lib64/pkgconfig
+ENV CFLAGS="-fexceptions -Wall -O3"
+ENV CXXFLAGS="${CFLAGS}"
 
 # Setup Some Dirs
 #
@@ -73,6 +75,33 @@ RUN git clone https://github.com/ImageOptim/libimagequant.git && \
 
 RUN cp -a /opt/lib/libimagequant.so* /build/share/lib/ && \
     cp -a /opt/include/libimagequant.h /build/share/include/
+
+# Install libfftw
+#
+RUN curl -L http://www.fftw.org/fftw-3.3.8.tar.gz > fftw-3.3.8.tar.gz && \
+    tar -xf fftw-3.3.8.tar.gz && \
+    cd ./fftw-3.3.8 && \
+    ./configure \
+      --prefix=/opt \
+      --enable-shared \
+      --disable-static \
+      --enable-threads \
+      --enable-sse2 \
+      --enable-avx && \
+    make && \
+    make install
+
+RUN cp -a /opt/lib/libfftw3* /build/share/lib/
+
+# Install liborc (perf)
+#
+RUN curl -L https://gstreamer.freedesktop.org/data/src/orc/orc-0.4.26.tar.xz > orc-0.4.26.tar.xz && \
+    tar -xf orc-0.4.26.tar.xz && \
+    cd orc-0.4.26 && \
+    ./configure --prefix=/opt && \
+    make && \
+    make install
+RUN cp -a /opt/lib/liborc-0.4.so* /build/share/lib/
 
 # Install libvips. Primary deps https://libvips.github.io/libvips/install.html
 #

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM lambci/lambda:build-ruby2.7
 
 WORKDIR /build
 
-ARG VIPS_VERSION=8.9.2
+ARG VIPS_VERSION=8.10.0
 
 ENV VIPS_VERSION=$VIPS_VERSION
 ENV PATH=/opt/bin:$PATH
@@ -93,6 +93,7 @@ RUN curl -L http://ftp.gnome.org/pub/gnome/sources/glib/2.64/glib-2.64.2.tar.xz 
     ninja install
 
 RUN cp -a /opt/lib64/libffi.so* /build/share/lib && \
+    cp -a /opt/lib64/libgio-2.0.so* /build/share/lib && \
     cp -a /opt/lib64/libglib-2.0.so* /build/share/lib && \
     cp -a /opt/lib64/libgmodule-2.0.so* /build/share/lib && \
     cp -a /opt/lib64/libgobject-2.0.so* /build/share/lib && \

--- a/README.md
+++ b/README.md
@@ -37,42 +37,45 @@ Current size of the layer's un-compressed contents is around `21MB` in size. Con
 
 ```shell
 $ ls -lAGp /opt/lib
-lrwxrwxrwx  1 root    18B Apr 29 23:53 libexpat.so -> libexpat.so.1.6.11
-lrwxrwxrwx  1 root    18B Apr 29 23:53 libexpat.so.1 -> libexpat.so.1.6.11
--rwxr-xr-x  1 root   543K Apr 29 23:53 libexpat.so.1.6.11
-lrwxrwxrwx  1 root    11B Apr 29 23:53 libffi.so -> libffi.so.7
-lrwxrwxrwx  1 root    15B Apr 29 23:53 libffi.so.7 -> libffi.so.7.1.0
--rwxr-xr-x  1 root   158K Apr 29 23:53 libffi.so.7.1.0
-lrwxrwxrwx  1 root    11B Apr 29 23:53 libgif.so -> libgif.so.7
-lrwxrwxrwx  1 root    15B Apr 29 23:53 libgif.so.7 -> libgif.so.7.2.0
--rwxr-xr-x  1 root    36K Apr 29 23:53 libgif.so.7.2.0
-lrwxrwxrwx  1 root    16B Apr 29 23:53 libglib-2.0.so -> libglib-2.0.so.0
-lrwxrwxrwx  1 root    23B Apr 29 23:53 libglib-2.0.so.0 -> libglib-2.0.so.0.6400.2
--rwxr-xr-x  1 root   4.7M Apr 29 23:53 libglib-2.0.so.0.6400.2
-lrwxrwxrwx  1 root    19B Apr 29 23:53 libgmodule-2.0.so -> libgmodule-2.0.so.0
-lrwxrwxrwx  1 root    26B Apr 29 23:53 libgmodule-2.0.so.0 -> libgmodule-2.0.so.0.6400.2
--rwxr-xr-x  1 root    49K Apr 29 23:53 libgmodule-2.0.so.0.6400.2
-lrwxrwxrwx  1 root    19B Apr 29 23:53 libgobject-2.0.so -> libgobject-2.0.so.0
-lrwxrwxrwx  1 root    26B Apr 29 23:53 libgobject-2.0.so.0 -> libgobject-2.0.so.0.6400.2
--rwxr-xr-x  1 root   1.7M Apr 29 23:53 libgobject-2.0.so.0.6400.2
-lrwxrwxrwx  1 root    19B Apr 29 23:53 libgthread-2.0.so -> libgthread-2.0.so.0
-lrwxrwxrwx  1 root    26B Apr 29 23:53 libgthread-2.0.so.0 -> libgthread-2.0.so.0.6400.2
--rwxr-xr-x  1 root    14K Apr 29 23:53 libgthread-2.0.so.0.6400.2
-lrwxrwxrwx  1 root    18B Apr 29 23:53 libimagequant.so -> libimagequant.so.0
--rw-r--r--  1 root    85K Apr 29 23:53 libimagequant.so.0
-lrwxrwxrwx  1 root    13B Apr 29 23:53 libjpeg.so -> libjpeg.so.62
-lrwxrwxrwx  1 root    17B Apr 29 23:53 libjpeg.so.62 -> libjpeg.so.62.3.0
--rwxr-xr-x  1 root   464K Apr 29 23:53 libjpeg.so.62.3.0
-lrwxrwxrwx  1 root    11B Apr 29 23:53 libpng.so -> libpng16.so
-lrwxrwxrwx  1 root    19B Apr 29 23:53 libpng16.so -> libpng16.so.16.37.0
-lrwxrwxrwx  1 root    19B Apr 29 23:53 libpng16.so.16 -> libpng16.so.16.37.0
--rwxr-xr-x  1 root   891K Apr 29 23:53 libpng16.so.16.37.0
-lrwxrwxrwx  1 root    17B Apr 29 23:53 libturbojpeg.so -> libturbojpeg.so.0
-lrwxrwxrwx  1 root    21B Apr 29 23:53 libturbojpeg.so.0 -> libturbojpeg.so.0.2.0
--rwxr-xr-x  1 root   583K Apr 29 23:53 libturbojpeg.so.0.2.0
-lrwxrwxrwx  1 root    18B Apr 29 23:53 libvips.so -> libvips.so.42.12.2
-lrwxrwxrwx  1 root    18B Apr 29 23:53 libvips.so.42 -> libvips.so.42.12.2
--rwxr-xr-x  1 root    11M Apr 29 23:53 libvips.so.42.12.2
+lrwxrwxrwx 1 root       18 Sep 11 01:56 libexpat.so -> libexpat.so.1.6.11
+lrwxrwxrwx 1 root       18 Sep 11 01:56 libexpat.so.1 -> libexpat.so.1.6.11
+-rwxr-xr-x 1 root   555824 Sep 11 01:56 libexpat.so.1.6.11
+lrwxrwxrwx 1 root       11 Sep 11 02:00 libffi.so -> libffi.so.7
+lrwxrwxrwx 1 root       15 Sep 11 02:00 libffi.so.7 -> libffi.so.7.1.0
+-rwxr-xr-x 1 root   161344 Sep 11 01:59 libffi.so.7.1.0
+lrwxrwxrwx 1 root       11 Sep 11 01:57 libgif.so -> libgif.so.7
+lrwxrwxrwx 1 root       15 Sep 11 01:57 libgif.so.7 -> libgif.so.7.2.0
+-rwxr-xr-x 1 root    36568 Sep 11 01:57 libgif.so.7.2.0
+lrwxrwxrwx 1 root       15 Sep 11 02:00 libgio-2.0.so -> libgio-2.0.so.0
+lrwxrwxrwx 1 root       22 Sep 11 02:00 libgio-2.0.so.0 -> libgio-2.0.so.0.6400.2
+-rwxr-xr-x 1 root  9625560 Sep 11 02:00 libgio-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       16 Sep 11 02:00 libglib-2.0.so -> libglib-2.0.so.0
+lrwxrwxrwx 1 root       23 Sep 11 02:00 libglib-2.0.so.0 -> libglib-2.0.so.0.6400.2
+-rwxr-xr-x 1 root  4938896 Sep 11 01:59 libglib-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       19 Sep 11 02:00 libgmodule-2.0.so -> libgmodule-2.0.so.0
+lrwxrwxrwx 1 root       26 Sep 11 02:00 libgmodule-2.0.so.0 -> libgmodule-2.0.so.0.6400.2
+-rwxr-xr-x 1 root    50048 Sep 11 02:00 libgmodule-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       19 Sep 11 02:00 libgobject-2.0.so -> libgobject-2.0.so.0
+lrwxrwxrwx 1 root       26 Sep 11 02:00 libgobject-2.0.so.0 -> libgobject-2.0.so.0.6400.2
+-rwxr-xr-x 1 root  1762800 Sep 11 02:00 libgobject-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       19 Sep 11 02:00 libgthread-2.0.so -> libgthread-2.0.so.0
+lrwxrwxrwx 1 root       26 Sep 11 02:00 libgthread-2.0.so.0 -> libgthread-2.0.so.0.6400.2
+-rwxr-xr-x 1 root    14824 Sep 11 02:00 libgthread-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       18 Sep 11 01:58 libimagequant.so -> libimagequant.so.0
+-rw-r--r-- 1 root    86912 Sep 11 01:58 libimagequant.so.0
+lrwxrwxrwx 1 root       13 Sep 11 01:58 libjpeg.so -> libjpeg.so.62
+lrwxrwxrwx 1 root       17 Sep 11 01:58 libjpeg.so.62 -> libjpeg.so.62.3.0
+-rwxr-xr-x 1 root   475448 Sep 11 01:58 libjpeg.so.62.3.0
+lrwxrwxrwx 1 root       19 Sep 11 01:57 libpng16.so -> libpng16.so.16.37.0
+lrwxrwxrwx 1 root       19 Sep 11 01:57 libpng16.so.16 -> libpng16.so.16.37.0
+-rwxr-xr-x 1 root   912200 Sep 11 01:57 libpng16.so.16.37.0
+lrwxrwxrwx 1 root       11 Sep 11 01:57 libpng.so -> libpng16.so
+lrwxrwxrwx 1 root       17 Sep 11 01:58 libturbojpeg.so -> libturbojpeg.so.0
+lrwxrwxrwx 1 root       21 Sep 11 01:58 libturbojpeg.so.0 -> libturbojpeg.so.0.2.0
+-rwxr-xr-x 1 root   596576 Sep 11 01:57 libturbojpeg.so.0.2.0
+lrwxrwxrwx 1 root       18 Sep 11 02:05 libvips.so -> libvips.so.42.12.3
+lrwxrwxrwx 1 root       18 Sep 11 02:05 libvips.so.42 -> libvips.so.42.12.3
+-rwxr-xr-x 1 root 12145616 Sep 11 02:05 libvips.so.42.12.3
 
 $ ls -lAGp /opt/include
 -rw-r--r--  1 root   6.8K Apr 29 23:53 libimagequant.h```

--- a/README.md
+++ b/README.md
@@ -33,49 +33,61 @@ Lastly, we were happy to find that `glib` and `gobject` were already installed a
 
 ## Contents
 
-Current size of the layer's un-compressed contents is around `21MB` in size. Contents include:
+Current size of the layer's un-compressed contents is around `28MB` in size. Contents include:
 
 ```shell
 $ ls -lAGp /opt/lib
-lrwxrwxrwx 1 root       18 Sep 11 01:56 libexpat.so -> libexpat.so.1.6.11
-lrwxrwxrwx 1 root       18 Sep 11 01:56 libexpat.so.1 -> libexpat.so.1.6.11
--rwxr-xr-x 1 root   555824 Sep 11 01:56 libexpat.so.1.6.11
-lrwxrwxrwx 1 root       11 Sep 11 02:00 libffi.so -> libffi.so.7
-lrwxrwxrwx 1 root       15 Sep 11 02:00 libffi.so.7 -> libffi.so.7.1.0
--rwxr-xr-x 1 root   161344 Sep 11 01:59 libffi.so.7.1.0
-lrwxrwxrwx 1 root       11 Sep 11 01:57 libgif.so -> libgif.so.7
-lrwxrwxrwx 1 root       15 Sep 11 01:57 libgif.so.7 -> libgif.so.7.2.0
--rwxr-xr-x 1 root    36568 Sep 11 01:57 libgif.so.7.2.0
-lrwxrwxrwx 1 root       15 Sep 11 02:00 libgio-2.0.so -> libgio-2.0.so.0
-lrwxrwxrwx 1 root       22 Sep 11 02:00 libgio-2.0.so.0 -> libgio-2.0.so.0.6400.2
--rwxr-xr-x 1 root  9625560 Sep 11 02:00 libgio-2.0.so.0.6400.2
-lrwxrwxrwx 1 root       16 Sep 11 02:00 libglib-2.0.so -> libglib-2.0.so.0
-lrwxrwxrwx 1 root       23 Sep 11 02:00 libglib-2.0.so.0 -> libglib-2.0.so.0.6400.2
--rwxr-xr-x 1 root  4938896 Sep 11 01:59 libglib-2.0.so.0.6400.2
-lrwxrwxrwx 1 root       19 Sep 11 02:00 libgmodule-2.0.so -> libgmodule-2.0.so.0
-lrwxrwxrwx 1 root       26 Sep 11 02:00 libgmodule-2.0.so.0 -> libgmodule-2.0.so.0.6400.2
--rwxr-xr-x 1 root    50048 Sep 11 02:00 libgmodule-2.0.so.0.6400.2
-lrwxrwxrwx 1 root       19 Sep 11 02:00 libgobject-2.0.so -> libgobject-2.0.so.0
-lrwxrwxrwx 1 root       26 Sep 11 02:00 libgobject-2.0.so.0 -> libgobject-2.0.so.0.6400.2
--rwxr-xr-x 1 root  1762800 Sep 11 02:00 libgobject-2.0.so.0.6400.2
-lrwxrwxrwx 1 root       19 Sep 11 02:00 libgthread-2.0.so -> libgthread-2.0.so.0
-lrwxrwxrwx 1 root       26 Sep 11 02:00 libgthread-2.0.so.0 -> libgthread-2.0.so.0.6400.2
--rwxr-xr-x 1 root    14824 Sep 11 02:00 libgthread-2.0.so.0.6400.2
-lrwxrwxrwx 1 root       18 Sep 11 01:58 libimagequant.so -> libimagequant.so.0
--rw-r--r-- 1 root    86912 Sep 11 01:58 libimagequant.so.0
-lrwxrwxrwx 1 root       13 Sep 11 01:58 libjpeg.so -> libjpeg.so.62
-lrwxrwxrwx 1 root       17 Sep 11 01:58 libjpeg.so.62 -> libjpeg.so.62.3.0
--rwxr-xr-x 1 root   475448 Sep 11 01:58 libjpeg.so.62.3.0
-lrwxrwxrwx 1 root       19 Sep 11 01:57 libpng16.so -> libpng16.so.16.37.0
-lrwxrwxrwx 1 root       19 Sep 11 01:57 libpng16.so.16 -> libpng16.so.16.37.0
--rwxr-xr-x 1 root   912200 Sep 11 01:57 libpng16.so.16.37.0
-lrwxrwxrwx 1 root       11 Sep 11 01:57 libpng.so -> libpng16.so
-lrwxrwxrwx 1 root       17 Sep 11 01:58 libturbojpeg.so -> libturbojpeg.so.0
-lrwxrwxrwx 1 root       21 Sep 11 01:58 libturbojpeg.so.0 -> libturbojpeg.so.0.2.0
--rwxr-xr-x 1 root   596576 Sep 11 01:57 libturbojpeg.so.0.2.0
-lrwxrwxrwx 1 root       18 Sep 11 02:05 libvips.so -> libvips.so.42.12.3
-lrwxrwxrwx 1 root       18 Sep 11 02:05 libvips.so.42 -> libvips.so.42.12.3
--rwxr-xr-x 1 root 12145616 Sep 11 02:05 libvips.so.42.12.3
+lrwxrwxrwx 1 root       18 Sep 19 22:46 libexpat.so -> libexpat.so.1.6.11
+lrwxrwxrwx 1 root       18 Sep 19 22:46 libexpat.so.1 -> libexpat.so.1.6.11
+-rwxr-xr-x 1 root   231496 Sep 19 22:46 libexpat.so.1.6.11
+lrwxrwxrwx 1 root       11 Sep 19 22:53 libffi.so -> libffi.so.7
+lrwxrwxrwx 1 root       15 Sep 19 22:53 libffi.so.7 -> libffi.so.7.1.0
+-rwxr-xr-x 1 root   196304 Sep 19 22:52 libffi.so.7.1.0
+-rwxr-xr-x 1 root      926 Sep 19 22:50 libfftw3.la
+lrwxrwxrwx 1 root       17 Sep 19 22:50 libfftw3.so -> libfftw3.so.3.5.8
+lrwxrwxrwx 1 root       17 Sep 19 22:50 libfftw3.so.3 -> libfftw3.so.3.5.8
+-rwxr-xr-x 1 root  2327176 Sep 19 22:50 libfftw3.so.3.5.8
+-rwxr-xr-x 1 root     1004 Sep 19 22:50 libfftw3_threads.la
+lrwxrwxrwx 1 root       25 Sep 19 22:50 libfftw3_threads.so -> libfftw3_threads.so.3.5.8
+lrwxrwxrwx 1 root       25 Sep 19 22:50 libfftw3_threads.so.3 -> libfftw3_threads.so.3.5.8
+-rwxr-xr-x 1 root    33968 Sep 19 22:50 libfftw3_threads.so.3.5.8
+lrwxrwxrwx 1 root       11 Sep 19 22:46 libgif.so -> libgif.so.7
+lrwxrwxrwx 1 root       15 Sep 19 22:46 libgif.so.7 -> libgif.so.7.2.0
+-rwxr-xr-x 1 root    36568 Sep 19 22:46 libgif.so.7.2.0
+lrwxrwxrwx 1 root       15 Sep 19 22:53 libgio-2.0.so -> libgio-2.0.so.0
+lrwxrwxrwx 1 root       22 Sep 19 22:53 libgio-2.0.so.0 -> libgio-2.0.so.0.6400.2
+-rwxr-xr-x 1 root 10701792 Sep 19 22:53 libgio-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       16 Sep 19 22:53 libglib-2.0.so -> libglib-2.0.so.0
+lrwxrwxrwx 1 root       23 Sep 19 22:53 libglib-2.0.so.0 -> libglib-2.0.so.0.6400.2
+-rwxr-xr-x 1 root  5742552 Sep 19 22:52 libglib-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       19 Sep 19 22:53 libgmodule-2.0.so -> libgmodule-2.0.so.0
+lrwxrwxrwx 1 root       26 Sep 19 22:53 libgmodule-2.0.so.0 -> libgmodule-2.0.so.0.6400.2
+-rwxr-xr-x 1 root    50400 Sep 19 22:53 libgmodule-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       19 Sep 19 22:53 libgobject-2.0.so -> libgobject-2.0.so.0
+lrwxrwxrwx 1 root       26 Sep 19 22:53 libgobject-2.0.so.0 -> libgobject-2.0.so.0.6400.2
+-rwxr-xr-x 1 root  1856656 Sep 19 22:53 libgobject-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       19 Sep 19 22:53 libgthread-2.0.so -> libgthread-2.0.so.0
+lrwxrwxrwx 1 root       26 Sep 19 22:53 libgthread-2.0.so.0 -> libgthread-2.0.so.0.6400.2
+-rwxr-xr-x 1 root    14840 Sep 19 22:53 libgthread-2.0.so.0.6400.2
+lrwxrwxrwx 1 root       18 Sep 19 22:47 libimagequant.so -> libimagequant.so.0
+-rw-r--r-- 1 root    62432 Sep 19 22:47 libimagequant.so.0
+lrwxrwxrwx 1 root       13 Sep 19 22:47 libjpeg.so -> libjpeg.so.62
+lrwxrwxrwx 1 root       17 Sep 19 22:47 libjpeg.so.62 -> libjpeg.so.62.3.0
+-rwxr-xr-x 1 root   475448 Sep 19 22:47 libjpeg.so.62.3.0
+lrwxrwxrwx 1 root       20 Sep 19 22:51 liborc-0.4.so -> liborc-0.4.so.0.25.0
+lrwxrwxrwx 1 root       20 Sep 19 22:51 liborc-0.4.so.0 -> liborc-0.4.so.0.25.0
+-rwxr-xr-x 1 root   797976 Sep 19 22:51 liborc-0.4.so.0.25.0
+lrwxrwxrwx 1 root       19 Sep 19 22:46 libpng16.so -> libpng16.so.16.37.0
+lrwxrwxrwx 1 root       19 Sep 19 22:46 libpng16.so.16 -> libpng16.so.16.37.0
+-rwxr-xr-x 1 root   285720 Sep 19 22:46 libpng16.so.16.37.0
+lrwxrwxrwx 1 root       11 Sep 19 22:46 libpng.so -> libpng16.so
+lrwxrwxrwx 1 root       17 Sep 19 22:47 libturbojpeg.so -> libturbojpeg.so.0
+lrwxrwxrwx 1 root       21 Sep 19 22:47 libturbojpeg.so.0 -> libturbojpeg.so.0.2.0
+-rwxr-xr-x 1 root   596576 Sep 19 22:47 libturbojpeg.so.0.2.0
+lrwxrwxrwx 1 root       18 Sep 19 22:58 libvips.so -> libvips.so.42.12.3
+lrwxrwxrwx 1 root       18 Sep 19 22:58 libvips.so.42 -> libvips.so.42.12.3
+-rwxr-xr-x 1 root  4257200 Sep 19 22:58 libvips.so.42.12.3
 
 $ ls -lAGp /opt/include
--rw-r--r--  1 root   6.8K Apr 29 23:53 libimagequant.h```
+-rw-r--r-- 1 root     6942 Sep 19 22:47 libimagequant.h
+```

--- a/bin/build
+++ b/bin/build
@@ -3,7 +3,7 @@
 set -e
 
 export IMAGE_NAME=ruby-vips-lambda
-export VIPS_VERSION=${VIPS_VERSION:=8.9.2}
+export VIPS_VERSION=${VIPS_VERSION:=8.10.0}
 
 rm -rf ./share
 mkdir ./share


### PR DESCRIPTION
Pretty standard, but I did notice we had to move `libgio` over. Not sure how it worked without it in previous versions.